### PR TITLE
fix: replace the schema 'postgres://' with 'postgresql://'

### DIFF
--- a/bookstore/books/db_connection.py
+++ b/bookstore/books/db_connection.py
@@ -50,7 +50,7 @@ def get_db_session():
     logger.info(f'Retrieving database access information from Secrets Manager\'s secret: "{db_secret_name}"')
     secrets = get_db_secrets()
     db_name = secrets['dbname']
-    db_conn_string = f"postgres://{secrets['username']}:{secrets['password']}@{db_proxy_endpoint}:{secrets['port']}/{db_name}?sslmode=require"
+    db_conn_string = f"postgresql://{secrets['username']}:{secrets['password']}@{db_proxy_endpoint}:{secrets['port']}/{db_name}?sslmode=require"
     
     logger.info(f'Creating SQLAlchemy database engine for database: "{db_name}"')
     engine = create_db_engine(db_conn_string)

--- a/db_schema/db_schema_lambda/main.py
+++ b/db_schema/db_schema_lambda/main.py
@@ -59,7 +59,7 @@ def create(event, context):
     logger.info(f'Retrieving database access information from Secrets Manager\'s secret: "{db_secret_name}"')
     secrets = get_db_secrets()
     db_name = secrets['dbname']
-    db_conn_string = f"postgres://{secrets['username']}:{secrets['password']}@{db_proxy_endpoint}:{secrets['port']}/{db_name}?sslmode=require"
+    db_conn_string = f"postgresql://{secrets['username']}:{secrets['password']}@{db_proxy_endpoint}:{secrets['port']}/{db_name}?sslmode=require"
 
     logger.info(f'Creating SQLAlchemy database engine for database: "{db_name}"')
     engine = create_db_engine(db_conn_string)


### PR DESCRIPTION
According to https://github.com/sqlalchemy/sqlalchemy/issues/6083, 'postgres://' is no longer supported in SQLAlchemy 1.4.x

*Issue #, if available: 
issue #2

*Description of changes:*
replace the schema 'postgres://' with 'postgresql://'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
